### PR TITLE
[feat] 모든 문제 목록 보기

### DIFF
--- a/src/main/java/com/nakaligoba/backend/controller/ProblemController.java
+++ b/src/main/java/com/nakaligoba/backend/controller/ProblemController.java
@@ -1,0 +1,41 @@
+package com.nakaligoba.backend.controller;
+
+import com.nakaligoba.backend.controller.dto.CustomPageResponse;
+import com.nakaligoba.backend.controller.dto.ProblemPagingDto;
+import com.nakaligoba.backend.entity.Problem;
+import com.nakaligoba.backend.repository.ProblemRepository;
+import com.nakaligoba.backend.service.ProblemService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.annotation.PostConstruct;
+import java.math.BigDecimal;
+import java.util.Arrays;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/problems")
+public class ProblemController {
+
+    private final ProblemService problemService;
+//    private final ProblemRepository problemRepository;
+
+    @GetMapping
+    public CustomPageResponse<ProblemPagingDto> readAllProblems(@PageableDefault(value = 3) Pageable pageable) {
+        Page<ProblemPagingDto> problemPage = problemService.getProblemList(pageable);
+        return new CustomPageResponse<>(problemPage);
+    }
+/*
+    @PostConstruct
+    public void init() {
+        for (int i = 1; i <= 10; i++) {
+            Problem problem = new Problem((long) i, "default description","Problem " + i,"쉬움", new BigDecimal("66.6"));
+            problemRepository.save(problem);
+        }
+    }*/
+}

--- a/src/main/java/com/nakaligoba/backend/controller/dto/CustomPageResponse.java
+++ b/src/main/java/com/nakaligoba/backend/controller/dto/CustomPageResponse.java
@@ -1,0 +1,29 @@
+package com.nakaligoba.backend.controller.dto;
+
+import lombok.Data;
+import org.springframework.data.domain.Page;
+
+import java.util.List;
+
+@Data
+public class CustomPageResponse<T> {
+    private List<T> problems;
+    private int totalPages;
+    private long totalElements;
+    private int number; // 현재 페이지
+    private int size; // 페이지당 크기
+    private int numberOfElements; // 현재 페이지의 요소 수
+    private boolean first;
+    private boolean last;
+
+    public CustomPageResponse(Page<T> page) {
+        this.problems = page.getContent();
+        this.totalPages = page.getTotalPages();
+        this.totalElements = page.getTotalElements();
+        this.number = page.getNumber();
+        this.size = page.getSize();
+        this.numberOfElements = page.getNumberOfElements();
+        this.first = page.isFirst();
+        this.last = page.isLast();
+    }
+}

--- a/src/main/java/com/nakaligoba/backend/controller/dto/ProblemPagingDto.java
+++ b/src/main/java/com/nakaligoba/backend/controller/dto/ProblemPagingDto.java
@@ -1,0 +1,38 @@
+package com.nakaligoba.backend.controller.dto;
+
+import com.nakaligoba.backend.entity.Problem;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ProblemPagingDto {
+
+    private Long id;
+    private Long number;
+    private String status;
+    private String title;
+    private BigDecimal acceptance;
+    private String difficulty;
+    private List<String> tags;
+
+    // Todo. 정답률, status 및 tags 수정하기
+    public ProblemPagingDto(Problem problem) {
+        this.id = problem.getId();
+        this.number = problem.getNumber();
+        this.status = "성공";
+        this.title = problem.getTitle();
+        this.acceptance = problem.getAcceptance();
+        this.difficulty = problem.getDifficulty();
+        this.tags = Arrays.asList("DFS", "BFS");
+    }
+}

--- a/src/main/java/com/nakaligoba/backend/entity/Problem.java
+++ b/src/main/java/com/nakaligoba/backend/entity/Problem.java
@@ -46,4 +46,12 @@ public class Problem extends BaseEntity {
 
     @OneToMany(mappedBy = "problem")
     private List<ProblemTag> problemTags = new ArrayList<>();
+
+    public Problem(Long number, String description, String title, String difficulty, BigDecimal acceptance) {
+        this.number = number;
+        this.description = description;
+        this.title = title;
+        this.difficulty = difficulty;
+        this.acceptance = acceptance;
+    }
 }

--- a/src/main/java/com/nakaligoba/backend/repository/ProblemRepository.java
+++ b/src/main/java/com/nakaligoba/backend/repository/ProblemRepository.java
@@ -1,0 +1,7 @@
+package com.nakaligoba.backend.repository;
+
+import com.nakaligoba.backend.entity.Problem;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ProblemRepository extends JpaRepository<Problem, Long> {
+}

--- a/src/main/java/com/nakaligoba/backend/service/ProblemService.java
+++ b/src/main/java/com/nakaligoba/backend/service/ProblemService.java
@@ -1,0 +1,23 @@
+package com.nakaligoba.backend.service;
+
+import com.nakaligoba.backend.controller.dto.ProblemPagingDto;
+import com.nakaligoba.backend.entity.Problem;
+import com.nakaligoba.backend.repository.ProblemRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class ProblemService {
+
+    private final ProblemRepository problemRepository;
+
+    @Transactional
+    public Page<ProblemPagingDto> getProblemList(Pageable pageable) {
+        Page<Problem> page = problemRepository.findAll(pageable);
+        return page.map(problem -> new ProblemPagingDto(problem));
+    }
+}


### PR DESCRIPTION
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `[feat] PR을 등록한다.` 
- [x] 💯 테스트는 잘 통과했나요?
- [x] 🏗️ 빌드는 성공했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?
- [x] 💻 git rebase를 사용했나요?

## 작업 내용
- API 명세대로 모든 문제 목록 보기를 구현하였습니다.
- 페이징처리를 위해 Pageable 인터페이스를 사용했습니다.
- 기본 Page 인터페이스 반환값인 Content가 아닌 Problems로 response 응답이 가기 위해 커스텀 페이지 DTO를 만들어 반환했습니다.

## 스크린샷

![image](https://github.com/NaKaLiGoBa/AlgoWithMe-BE/assets/67509973/c82cd424-4dea-46d6-9a98-7ed90f960e71)

![image](https://github.com/NaKaLiGoBa/AlgoWithMe-BE/assets/67509973/195fc4d2-c45e-41a3-ac09-7100a2abd82d)

![image](https://github.com/NaKaLiGoBa/AlgoWithMe-BE/assets/67509973/bc9fbdec-a6b3-4f24-ac5e-65135b796f05)

## 주의사항

- 김영한님 강의를 참고하여 @PostContruct를 이용해 테스트하였습니다. 보통 테스트할 때 사용하면 DB에 남을 수 있어 보통 운영단계에서
사용하면 안되는 것으로 알고 있어, 이 부분 수정하도록 하겠습니다.
- 기본적으로 Pageable은 page=0부터 시작하는데, 이 부분은 1로 수정할 수 있습니다.
- @PageableDefault(value=)로 페이징값을 수정할 수 있고, application.yml에서도 기본값을 줄 수 있습니다.
- status와 정답률 그리고 tag 메서드들을 만들어보려고 시도하였으나 문제 생성 로직이 먼저 선행되어야 진행할 수 있다고 판단이 들어서 기본 데이터값으로 이번에 대체하였습니다 ㅜㅜ

Closes #{issueNumber}
