### PR TITLE
[refactor] 모든 문제 목록 보기 page 인터페이스 관련 리팩토링

### DIFF
--- a/src/main/java/com/nakaligoba/backend/problem/application/ProblemService.java
+++ b/src/main/java/com/nakaligoba/backend/problem/application/ProblemService.java
@@ -2,6 +2,7 @@ package com.nakaligoba.backend.problem.application;
 
 import com.nakaligoba.backend.availablelanguage.domain.AvailableLanguage;
 import com.nakaligoba.backend.problem.application.dto.ProblemPagingDto;
+import com.nakaligoba.backend.problem.controller.dto.CustomPageResponse;
 import com.nakaligoba.backend.problem.controller.dto.InputDto;
 import com.nakaligoba.backend.problem.controller.dto.ProblemResponse;
 import com.nakaligoba.backend.problem.domain.Problem;
@@ -27,9 +28,31 @@ public class ProblemService {
 
     private final ProblemRepository problemRepository;
 
-    public Page<ProblemPagingDto> getProblemList(Pageable pageable) {
+    public CustomPageResponse<ProblemPagingDto> getProblemList(Pageable pageable) {
         Page<Problem> page = problemRepository.findAll(pageable);
-        return page.map(problem -> new ProblemPagingDto(problem));
+        List<ProblemPagingDto> dtos = page.getContent().stream()
+                .map(problem -> new ProblemPagingDto(
+                        problem.getId(),
+                        problem.getNumber(),
+                        getStatus(problem),
+                        problem.getTitle(),
+                        problem.getAcceptance(),
+                        problem.getDifficulty(),
+                        getTags(problem)
+                ))
+                .collect(Collectors.toList());
+
+        CustomPageResponse<ProblemPagingDto> response = CustomPageResponse.<ProblemPagingDto>builder()
+                .problems(dtos)
+                .pageNumber(page.getNumber())
+                .totalPages(page.getTotalPages())
+                .totalElements(page.getTotalElements())
+                .size(page.getSize())
+                .numberOfElements(page.getNumberOfElements())
+                .first(page.isFirst())
+                .last(page.isLast())
+                .build();
+        return response;
     }
 
     public ProblemResponse readProblem(Long id) {

--- a/src/main/java/com/nakaligoba/backend/problem/application/dto/ProblemPagingDto.java
+++ b/src/main/java/com/nakaligoba/backend/problem/application/dto/ProblemPagingDto.java
@@ -23,15 +23,4 @@ public class ProblemPagingDto {
     private BigDecimal acceptance;
     private String difficulty;
     private List<String> tags;
-
-    // Todo. 정답률, status 및 tags 수정하기
-    public ProblemPagingDto(Problem problem) {
-        this.id = problem.getId();
-        this.number = problem.getNumber();
-        this.status = "성공";
-        this.title = problem.getTitle();
-        this.acceptance = problem.getAcceptance();
-        this.difficulty = problem.getDifficulty();
-        this.tags = Arrays.asList("DFS", "BFS");
-    }
 }

--- a/src/main/java/com/nakaligoba/backend/problem/controller/ProblemController.java
+++ b/src/main/java/com/nakaligoba/backend/problem/controller/ProblemController.java
@@ -5,9 +5,7 @@ import com.nakaligoba.backend.problem.application.dto.ProblemPagingDto;
 import com.nakaligoba.backend.problem.application.ProblemService;
 import com.nakaligoba.backend.problem.controller.dto.ProblemResponse;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -20,21 +18,12 @@ import org.springframework.web.bind.annotation.RestController;
 public class ProblemController {
 
     private final ProblemService problemService;
-//    private final ProblemRepository problemRepository;
 
     @GetMapping
-    public CustomPageResponse<ProblemPagingDto> readAllProblems(@PageableDefault(value = 3) Pageable pageable) {
-        Page<ProblemPagingDto> problemPage = problemService.getProblemList(pageable);
-        return new CustomPageResponse<>(problemPage);
+    public ResponseEntity<CustomPageResponse<ProblemPagingDto>> readAllProblems(Pageable pageable) {
+        CustomPageResponse<ProblemPagingDto> response = problemService.getProblemList(pageable);
+        return ResponseEntity.ok(response);
     }
-/*
-    @PostConstruct
-    public void init() {
-        for (int i = 1; i <= 10; i++) {
-            Problem problem = new Problem((long) i, "default description","Problem " + i,"쉬움", new BigDecimal("66.6"));
-            problemRepository.save(problem);
-        }
-    }*/
 
     @GetMapping("/{id}")
     public ResponseEntity<ProblemResponse> readProblem(@PathVariable Long id) {

--- a/src/main/java/com/nakaligoba/backend/problem/controller/dto/CustomPageResponse.java
+++ b/src/main/java/com/nakaligoba/backend/problem/controller/dto/CustomPageResponse.java
@@ -1,29 +1,32 @@
 package com.nakaligoba.backend.problem.controller.dto;
 
+import lombok.Builder;
 import lombok.Data;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 import java.util.List;
 
 @Data
+@Builder
 public class CustomPageResponse<T> {
     private List<T> problems;
-    private int totalPages;
-    private long totalElements;
-    private int number; // 현재 페이지
-    private int size; // 페이지당 크기
+    private int pageNumber;     // 현재 페이지
+    private int totalPages;     // 모든 페이지의 수
+    private long totalElements; // content의 총 개수
+    private int size;           // 페이지당 크기
     private int numberOfElements; // 현재 페이지의 요소 수
     private boolean first;
     private boolean last;
 
-    public CustomPageResponse(Page<T> page) {
-        this.problems = page.getContent();
-        this.totalPages = page.getTotalPages();
-        this.totalElements = page.getTotalElements();
-        this.number = page.getNumber();
-        this.size = page.getSize();
-        this.numberOfElements = page.getNumberOfElements();
-        this.first = page.isFirst();
-        this.last = page.isLast();
+    public CustomPageResponse(List<T> problems, int pageNumber, int totalPages, long totalElements, int size, int numberOfElements, boolean first, boolean last) {
+        this.problems = problems;
+        this.pageNumber = pageNumber;
+        this.totalPages = totalPages;
+        this.totalElements = totalElements;
+        this.size = size;
+        this.numberOfElements = numberOfElements;
+        this.first = first;
+        this.last = last;
     }
 }

--- a/src/main/resources/application-test.yaml
+++ b/src/main/resources/application-test.yaml
@@ -16,3 +16,9 @@ spring:
     hibernate:
       ddl-auto: create
 
+  data:
+    web:
+      pageable:
+        default-page-size: 5
+        max-page-size: 2000
+        one-indexed-parameters: true


### PR DESCRIPTION
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `[feat] PR을 등록한다.` 
- [x] 💯 테스트는 잘 통과했나요?
- [x] 🏗️ 빌드는 성공했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?
- [x] 💻 git rebase를 사용했나요?

## 작업 내용

- 대은님이 조언주셨던 springframework.data 패키지에 의존성에 대해 조사하고 개선하여 적용해보았습니다.
- 그에 따라 컨트롤러 getProblemList에서 Pageable를 받아 서비스 레이어에서 response해야 할 스펙대로
dtos 리스트를 생성합니다.
- 생성된 dtos 리스트를 Page 인터페이스 타입의 CustomPageResponse 객체에 담아 컨트롤러에 반환합니다.
- 그래서 API 스펙의 데이터를 보내고, 프론트에서 사용할 페이지 네이게이션바에 필요한 Page 데이터도 같이 반환합니다.
- @PageableDefault(value=xx)를 지우고 resource에서 관리될 수 있게 하였습니다.
- 컨트롤러에 테스트하려고 작성했던 코드들을 테스트하고 지웠습니다.

## 스크린샷

![image](https://github.com/NaKaLiGoBa/AlgoWithMe-BE/assets/67509973/fd9ac25c-7555-420e-abc1-316341e90e3e)
![image](https://github.com/NaKaLiGoBa/AlgoWithMe-BE/assets/67509973/c466ed3e-0500-42e3-84ab-8f9f9d9e66b8)


## 주의사항

- 페이지 디폴트 값은 0부터 시작입니다. 하지만 resource에서 one-indexed-parameters: true를 추가하여
?page=0 과 ?page=1 은 모두 1페이지입니다. 불편할 수 있어 문제가 되면 수정하도록 하겠습니다.
- 반환한 페이지 스펙은 
pageNumber = 현재 페이지 (?page=0 과 ?page=1 모두 pageNumber는 0입니다.)
totalPage = 전체 페이지 개수
totalElements : 문제 목록의 총 개수
size : 한 페이지에 불러오는 문제 목록의 개수
numberOfElements : 현재 페이지의 문제 목록의 개수
first : 첫번째 페이지면 true로, 이전 페이지버튼이 활성화되지 않도록 할 수 있습니다.
last : 마지막 페이지면 true로, 다음 페이지버튼이 활성화되지 않도록 할 수 있습니다.

위의 사진은
- 총 문제의 개수 : 21개
- 한 페이지에 불러올 문제의 개수 : 5개
이렇게 설정하였습니다!

Closes #{issueNumber}
