### PR TITLE
[feat] 풀이 글 수정 기능 추가

### DIFF
--- a/src/main/java/com/nakaligoba/backend/solution/application/SolutionService.java
+++ b/src/main/java/com/nakaligoba/backend/solution/application/SolutionService.java
@@ -79,6 +79,10 @@ public class SolutionService {
                 .orElseThrow(IllegalAccessError::new))
                 .collect(Collectors.toList());
 
+         if (!solution.getMember().getId().equals(member.getId())) {
+            throw new UnauthorizedException("권한이 없습니다.");
+        }
+
         solution.updateSolutionLanguages(programmingLanguages);
         solutionRepository.save(solution);
 

--- a/src/main/java/com/nakaligoba/backend/solution/application/SolutionService.java
+++ b/src/main/java/com/nakaligoba/backend/solution/application/SolutionService.java
@@ -6,7 +6,7 @@ import com.nakaligoba.backend.problem.domain.Problem;
 import com.nakaligoba.backend.problem.domain.ProblemRepository;
 import com.nakaligoba.backend.programminglanguage.domain.ProgrammingLanguage;
 import com.nakaligoba.backend.programminglanguage.domain.ProgrammingLanguageRepository;
-import com.nakaligoba.backend.solution.controller.dto.SolutionCreateRequest;
+import com.nakaligoba.backend.solution.controller.dto.SolutionRequest;
 import com.nakaligoba.backend.solution.domain.Solution;
 import com.nakaligoba.backend.solution.domain.SolutionRepository;
 import com.nakaligoba.backend.solutionlanguage.domain.SolutionLanguage;
@@ -14,7 +14,10 @@ import com.nakaligoba.backend.solutionlanguage.domain.SolutionLanguageRepository
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import javax.persistence.EntityNotFoundException;
 import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
 
 @RequiredArgsConstructor
 @Service
@@ -26,7 +29,7 @@ public class SolutionService {
     private final ProgrammingLanguageRepository programmingLanguageRepository;
     private final SolutionLanguageRepository solutionLanguageRepository;
 
-    public long createSolution(String writerEmail, long problemId, SolutionCreateRequest request) {
+    public long createSolution(String writerEmail, long problemId, SolutionRequest request) {
         Member member = memberRepository.findByEmail(writerEmail);
         Problem problem = problemRepository.findById(problemId)
                 .orElseThrow(IllegalArgumentException::new);
@@ -54,6 +57,30 @@ public class SolutionService {
         }
 
         solutionLanguageRepository.saveAll(solutionLanguages);
+
+        return solution.getId();
+    }
+
+    public Long updateSolution(String writerEmail, Long problemId, Long solutionId, SolutionRequest request) {
+        Member member = memberRepository.findByEmail(writerEmail);
+        if (member == null) {
+            throw new EntityNotFoundException("회원을 찾을 수 없습니다.");
+        }
+        Problem problem = problemRepository.findById(problemId)
+                .orElseThrow(IllegalAccessError::new);
+        Solution solution = solutionRepository.findById(solutionId)
+                .orElseThrow(IllegalAccessError::new);
+
+        solution.changeTitle(request.getTitle());
+        solution.changeContent(request.getContent());
+
+        List<ProgrammingLanguage> programmingLanguages = request.getLanguages().stream()
+                .map(language -> programmingLanguageRepository.findByName(language)
+                .orElseThrow(IllegalAccessError::new))
+                .collect(Collectors.toList());
+
+        solution.updateSolutionLanguages(programmingLanguages);
+        solutionRepository.save(solution);
 
         return solution.getId();
     }

--- a/src/main/java/com/nakaligoba/backend/solution/application/SolutionService.java
+++ b/src/main/java/com/nakaligoba/backend/solution/application/SolutionService.java
@@ -70,6 +70,10 @@ public class SolutionService {
                 .orElseThrow(IllegalAccessError::new);
         Solution solution = solutionRepository.findById(solutionId)
                 .orElseThrow(IllegalAccessError::new);
+        
+        if (!solution.getMember().getId().equals(member.getId())) {
+            throw new UnauthorizedException("권한이 없습니다.");
+        }
 
         solution.changeTitle(request.getTitle());
         solution.changeContent(request.getContent());
@@ -78,10 +82,6 @@ public class SolutionService {
                 .map(language -> programmingLanguageRepository.findByName(language)
                 .orElseThrow(IllegalAccessError::new))
                 .collect(Collectors.toList());
-
-         if (!solution.getMember().getId().equals(member.getId())) {
-            throw new UnauthorizedException("권한이 없습니다.");
-        }
 
         solution.updateSolutionLanguages(programmingLanguages);
         solutionRepository.save(solution);

--- a/src/main/java/com/nakaligoba/backend/solution/controller/SolutionController.java
+++ b/src/main/java/com/nakaligoba/backend/solution/controller/SolutionController.java
@@ -1,7 +1,7 @@
 package com.nakaligoba.backend.solution.controller;
 
 import com.nakaligoba.backend.solution.application.SolutionService;
-import com.nakaligoba.backend.solution.controller.dto.SolutionCreateRequest;
+import com.nakaligoba.backend.solution.controller.dto.SolutionRequest;
 import com.nakaligoba.backend.utils.JwtUtils;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -20,12 +20,26 @@ public class SolutionController {
     private final SolutionService solutionService;
 
     @PostMapping("/{id}/solutions")
-    public ResponseEntity<Void> createSolution(@PathVariable("id") long id, @RequestBody @Valid SolutionCreateRequest request) {
+    public ResponseEntity<Void> createSolution(@PathVariable("id") long id, @RequestBody @Valid SolutionRequest request) {
         String writerEmail = JwtUtils.getEmailFromSpringSession();
         long createdSolutionId = solutionService.createSolution(writerEmail, id, request);
 
         return ResponseEntity.status(HttpStatus.CREATED)
                 .header("Location", "https://k08e0a348244ea.user-app.krampoline.com/api/v1/problems/" + id + "/solutions/" + createdSolutionId)
                 .build();
+    }
+
+    @PutMapping("{problemId}/solutions/{solutionId}")
+    public ResponseEntity<Void> updateSolution(
+            @PathVariable Long problemId,
+            @PathVariable Long solutionId,
+            @RequestBody SolutionRequest request
+    ){
+        String writerEmail = JwtUtils.getEmailFromSpringSession();
+        Long updatedSolutionId = solutionService.updateSolution(writerEmail, problemId, solutionId, request);
+
+        return ResponseEntity.status(HttpStatus.CREATED)
+              .header("Location", "https://k08e0a348244ea.user-app.krampoline.com/api/v1/problems/" + problemId + "/solutions/" + updatedSolutionId)
+              .build();
     }
 }

--- a/src/main/java/com/nakaligoba/backend/solution/controller/dto/SolutionRequest.java
+++ b/src/main/java/com/nakaligoba/backend/solution/controller/dto/SolutionRequest.java
@@ -7,7 +7,7 @@ import javax.validation.constraints.NotEmpty;
 import java.util.ArrayList;
 
 @Data
-public class SolutionCreateRequest {
+public class SolutionRequest {
     @NotBlank
     private String title;
 

--- a/src/main/java/com/nakaligoba/backend/solution/domain/Solution.java
+++ b/src/main/java/com/nakaligoba/backend/solution/domain/Solution.java
@@ -3,6 +3,7 @@ package com.nakaligoba.backend.solution.domain;
 import com.nakaligoba.backend.global.BaseEntity;
 import com.nakaligoba.backend.member.domain.Member;
 import com.nakaligoba.backend.problem.domain.Problem;
+import com.nakaligoba.backend.programminglanguage.domain.ProgrammingLanguage;
 import com.nakaligoba.backend.solutionlanguage.domain.SolutionLanguage;
 import lombok.*;
 
@@ -44,5 +45,19 @@ public class Solution extends BaseEntity {
         this.content = content;
         this.member = member;
         this.problem = problem;
+    }
+
+    public void changeTitle(String title) {
+        this.title = title;
+    }
+    public void changeContent(String content) {
+        this.content = content;
+    }
+
+    public void updateSolutionLanguages(List<ProgrammingLanguage> programmingLanguages) {
+        this.solutionLanguages.clear();
+        for (ProgrammingLanguage programmingLanguage : programmingLanguages) {
+            this.solutionLanguages.add(new SolutionLanguage(this, programmingLanguage));
+        }
     }
 }


### PR DESCRIPTION
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `[feat] PR을 등록한다.` 
- [x] 💯 테스트는 잘 통과했나요?
- [x] 🏗️ 빌드는 성공했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?
- [x] 💻 git rebase를 사용했나요?

## 작업 내용
- 생성된 페이지 풀이 글에서 PUT HTTP 메서드로 수정할 필드들을 모두 새로 받습니다.
- 작성자, 문제 식별자, 풀이 글 식별자, request body를 받아 회원, 문제, 풀이 글 모두 검증을 합니다.
- 그런 다음 Solution Entity에 Title, Content 수정 메서드와 ProgrammingLanguage 리스트를 초기화하고 새로 추가를 위해 
초기화하고 새로 받은 언어들을 저장하는 메서드도 추가하여 캡슐화를 수행하려고 했습니다. 
+
이 로직들을 검증하는데 애를 많이 먹었습니다😂 반환값이 주소값이라 데이터를 보고 싶어서 기존에 Postman으로는 안될 것 같았습니다..
그래서 테스트 코드 작성중 너무 복잡하여, H2로 확인하려 했으나 H2와 연결이 뭔가 안되는 것같아서
지난 풀이글 생성때 석진님께서 MySQL로 테스트하신게 기억이 나서 MySQL로 테스트하려고 이것저것 시도하여 테스트를 수행할 수 있게되었습니다! 석진님 감사합니다! 대은님도 항상 감사합니다!

## 스크린샷

< 서버 실행 시 넣은 Problem 객체 >
![image](https://github.com/NaKaLiGoBa/AlgoWithMe-BE/assets/67509973/4073e349-2dc0-4fb0-bdd9-eed634ab236f)

< 생성한 풀이 글 >
![image](https://github.com/NaKaLiGoBa/AlgoWithMe-BE/assets/67509973/c9840ba8-2fba-439e-9b64-ff8d97317d39)

< 수정된 결과 >
![image](https://github.com/NaKaLiGoBa/AlgoWithMe-BE/assets/67509973/376f7cf8-844b-41fb-acdb-a5e160023fb3)

< 상태 코드 와 반환 주소 >
![image](https://github.com/NaKaLiGoBa/AlgoWithMe-BE/assets/67509973/21fad750-2777-4c65-911c-c5bfe2cafa73)

< Solution_Languages 수정 시 >
![image](https://github.com/NaKaLiGoBa/AlgoWithMe-BE/assets/67509973/ecedd03f-ea76-4d63-84a0-aef55c371c2b)



## 주의사항

- ProgrammingLanguage는 Java와 Python 두 개를 생성했습니다

Closes #{issueNumber}
