### PR TITLE
[feat] 풀이 게시글 삭제 기능 추가

### DIFF
--- a/src/main/java/com/nakaligoba/backend/member/domain/Member.java
+++ b/src/main/java/com/nakaligoba/backend/member/domain/Member.java
@@ -8,6 +8,7 @@ import lombok.*;
 import javax.persistence.*;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 @Entity
 @Table(name = "members")
@@ -40,5 +41,18 @@ public class Member extends BaseEntity {
         this.email = email;
         this.password = password;
         this.nickname = nickname;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Member member = (Member) o;
+        return Objects.equals(id, member.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id);
     }
 }

--- a/src/main/java/com/nakaligoba/backend/solution/application/SolutionService.java
+++ b/src/main/java/com/nakaligoba/backend/solution/application/SolutionService.java
@@ -1,5 +1,6 @@
 package com.nakaligoba.backend.solution.application;
 
+import com.github.dockerjava.api.exception.UnauthorizedException;
 import com.nakaligoba.backend.member.domain.Member;
 import com.nakaligoba.backend.member.domain.MemberRepository;
 import com.nakaligoba.backend.problem.domain.Problem;
@@ -70,22 +71,36 @@ public class SolutionService {
                 .orElseThrow(IllegalAccessError::new);
         Solution solution = solutionRepository.findById(solutionId)
                 .orElseThrow(IllegalAccessError::new);
-        
-        if (!solution.getMember().getId().equals(member.getId())) {
-            throw new UnauthorizedException("권한이 없습니다.");
-        }
 
         solution.changeTitle(request.getTitle());
         solution.changeContent(request.getContent());
 
         List<ProgrammingLanguage> programmingLanguages = request.getLanguages().stream()
                 .map(language -> programmingLanguageRepository.findByName(language)
-                .orElseThrow(IllegalAccessError::new))
+                        .orElseThrow(IllegalAccessError::new))
                 .collect(Collectors.toList());
 
         solution.updateSolutionLanguages(programmingLanguages);
         solutionRepository.save(solution);
 
         return solution.getId();
+    }
+
+    public void removeSolution(String writerEmail, Long problemId, Long solutionId) {
+        Member member = memberRepository.findByEmail(writerEmail);
+        if (member == null) {
+            throw new IllegalAccessError();
+        }
+        Problem problem = problemRepository.findById(problemId)
+                .orElseThrow(IllegalArgumentException::new);
+        Solution solution = solutionRepository.findById(solutionId)
+                .orElseThrow(IllegalAccessError::new);
+
+
+        if (!solution.getMember().getId().equals(member.getId())) {
+            throw new UnauthorizedException("권한이 없습니다.");
+        }
+
+        solutionRepository.delete(solution);
     }
 }

--- a/src/main/java/com/nakaligoba/backend/solution/application/SolutionService.java
+++ b/src/main/java/com/nakaligoba/backend/solution/application/SolutionService.java
@@ -97,7 +97,7 @@ public class SolutionService {
                 .orElseThrow(IllegalAccessError::new);
 
 
-        if (!solution.getMember().getId().equals(member.getId())) {
+        if (!solution.getMember().equals(member)) {
             throw new UnauthorizedException("권한이 없습니다.");
         }
 

--- a/src/main/java/com/nakaligoba/backend/solution/controller/SolutionController.java
+++ b/src/main/java/com/nakaligoba/backend/solution/controller/SolutionController.java
@@ -34,12 +34,23 @@ public class SolutionController {
             @PathVariable Long problemId,
             @PathVariable Long solutionId,
             @RequestBody SolutionRequest request
-    ){
+    ) {
         String writerEmail = JwtUtils.getEmailFromSpringSession();
         Long updatedSolutionId = solutionService.updateSolution(writerEmail, problemId, solutionId, request);
 
         return ResponseEntity.status(HttpStatus.CREATED)
-              .header("Location", "https://k08e0a348244ea.user-app.krampoline.com/api/v1/problems/" + problemId + "/solutions/" + updatedSolutionId)
-              .build();
+                .header("Location", "https://k08e0a348244ea.user-app.krampoline.com/api/v1/problems/" + problemId + "/solutions/" + updatedSolutionId)
+                .build();
+    }
+
+    @DeleteMapping("/{problemId}/solutions/{solutionId}")
+    public ResponseEntity<Void> removeSolution(
+            @PathVariable Long problemId,
+            @PathVariable Long solutionId
+    ){
+        String writerEmail = JwtUtils.getEmailFromSpringSession();
+        solutionService.removeSolution(writerEmail, problemId, solutionId);
+
+        return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
     }
 }

--- a/src/main/java/com/nakaligoba/backend/solution/domain/Solution.java
+++ b/src/main/java/com/nakaligoba/backend/solution/domain/Solution.java
@@ -36,7 +36,7 @@ public class Solution extends BaseEntity {
     @JoinColumn(name = "problem_id", nullable = false)
     private Problem problem;
 
-    @OneToMany(mappedBy = "solution")
+    @OneToMany(mappedBy = "solution", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<SolutionLanguage> solutionLanguages = new ArrayList<>();
 
     @Builder


### PR DESCRIPTION
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `[feat] PR을 등록한다.` 
- [x] 💯 테스트는 잘 통과했나요?
- [x] 🏗️ 빌드는 성공했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?
- [x] 💻 git rebase를 사용했나요?

## 작업 내용

- 풀이 작성자와 문제 식별자 그리고 풀이 글 식별자를 받아 멤버, 문제, 풀이를 검증하고,
작성자가 DB에 존재하는 것 이외에 풀이 글을 작성한 사람이 맞는지 권한 검사를 진행하기 위해
Member 엔티티에 equals, hashcode를 오버라이드 했습니다.

- 풀이 글(Solution)과 풀이 언어(Solution_language)는 생명주기를 함께 해야 된다고 생각해 Cascade.ALL과 고아객체를 
부모 객체인 Solution 엔티티의 solutionLanguage 필드에 선언하였습니다.  

## 스크린샷

< 생성한 풀이 글 + 삭제 결과 > 
![image](https://github.com/NaKaLiGoBa/AlgoWithMe-BE/assets/67509973/20a1ace7-c24c-4cd0-9661-ba1d5a1d3f2a)

< 상태코드 >
![image](https://github.com/NaKaLiGoBa/AlgoWithMe-BE/assets/67509973/1447e5b2-3842-4c8a-a5a9-994edbdc8b03)


## 주의사항

Closes #{issueNumber}
