### PR TITLE
[feat] 문제 조회 시 디폴트 코드 응답

### DIFF
--- a/src/main/java/com/nakaligoba/backend/service/impl/ProblemService.java
+++ b/src/main/java/com/nakaligoba/backend/service/impl/ProblemService.java
@@ -1,5 +1,6 @@
 package com.nakaligoba.backend.service.impl;
 
+import com.nakaligoba.backend.domain.Language;
 import com.nakaligoba.backend.service.dto.ProblemPagingDto;
 import com.nakaligoba.backend.controller.payload.response.CustomPageResponse;
 import com.nakaligoba.backend.controller.payload.response.ProblemResponse;
@@ -19,6 +20,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
@@ -102,10 +104,10 @@ public class ProblemService {
                 .orElseThrow(NoSuchElementException::new);
         String[] args = testcase.getInputNamesAsList()
                 .toArray(String[]::new);
-        return problem.getAvailableLanguages().stream()
+        return Arrays.stream(Language.values())
                 .collect(Collectors.toMap(
-                        l -> l.getProgrammingLanguage().getName().getName(),
-                        l -> l.getProgrammingLanguage().getName().getDefaultCode(args)
+                        Language::getName,
+                        l -> l.getDefaultCode(args)
                 ));
     }
 

--- a/src/test/java/com/nakaligoba/backend/acceptance/ProblemAcceptanceTest.java
+++ b/src/test/java/com/nakaligoba/backend/acceptance/ProblemAcceptanceTest.java
@@ -1,10 +1,12 @@
 package com.nakaligoba.backend.acceptance;
 
+import com.nakaligoba.backend.acceptance.fixtures.ProblemFixture;
 import com.nakaligoba.backend.controller.payload.request.CreateProblemRequest;
 import io.restassured.http.ContentType;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.test.context.support.WithMockUser;
 
@@ -18,12 +20,13 @@ public class ProblemAcceptanceTest extends AcceptanceTest {
     @Test
     @DisplayName("문제 식별자로 문제 설명을 볼 수 있다.")
     void givenProblemId_whenRequest_thenProblemData() {
-        long problemId = 1L;
+        String problemLocation = ProblemFixture.createProblem()
+                .header(HttpHeaders.LOCATION);
 
         given()
                 .log().all()
         .when()
-                .get("/api/v1/problems/" + problemId)
+                .get(problemLocation)
         .then()
                 .log().all()
                 .assertThat()
@@ -34,19 +37,9 @@ public class ProblemAcceptanceTest extends AcceptanceTest {
     @DisplayName("문제 생성")
     @WithMockUser
     void createProblem() {
-        CreateProblemRequest requestBody = new CreateProblemRequest(
-                "겁나 어려운 문제",
-                "어려움",
-                "# 설명\n매우 어려운 설명\n## 소제목",
-                Arrays.asList("a", "b"),
-                "1 2\n3",
-                "3 4\n7",
-                Arrays.asList("DFS", "BFS")
-        );
-
         given()
                 .log().all()
-                .body(requestBody)
+                .body(ProblemFixture.CREATE_PROBLEM_REQUEST)
                 .contentType(ContentType.JSON)
         .when()
                 .post("/api/v1/problems")

--- a/src/test/java/com/nakaligoba/backend/acceptance/ProblemAcceptanceTest.java
+++ b/src/test/java/com/nakaligoba/backend/acceptance/ProblemAcceptanceTest.java
@@ -47,7 +47,7 @@ public class ProblemAcceptanceTest extends AcceptanceTest {
                 .log().all()
                 .assertThat()
                 .statusCode(HttpStatus.CREATED.value())
-                .header("Location", Matchers.notNullValue());
+                .header(HttpHeaders.LOCATION, Matchers.notNullValue());
     }
 
     @Test
@@ -74,7 +74,7 @@ public class ProblemAcceptanceTest extends AcceptanceTest {
                 .log().all()
                 .assertThat()
                 .statusCode(HttpStatus.CREATED.value())
-                .header("Location", Matchers.notNullValue());
+                .header(HttpHeaders.LOCATION, Matchers.notNullValue());
     }
 
     @Test

--- a/src/test/java/com/nakaligoba/backend/acceptance/fixtures/ProblemFixture.java
+++ b/src/test/java/com/nakaligoba/backend/acceptance/fixtures/ProblemFixture.java
@@ -11,20 +11,18 @@ import static io.restassured.RestAssured.given;
 
 public class ProblemFixture {
 
-    public static ExtractableResponse<Response> createProblem() {
-        CreateProblemRequest requestBody = new CreateProblemRequest(
-                "겁나 어려운 문제",
-                "어려움",
-                "# 설명\n매우 어려운 설명\n## 소제목",
-                Arrays.asList("a", "b"),
-                "1 2\n3",
-                "3 4\n7",
-                Arrays.asList("DFS", "BFS")
-        );
+    public final static CreateProblemRequest CREATE_PROBLEM_REQUEST = new CreateProblemRequest("겁나 어려운 문제",
+            "어려움",
+            "# 설명\n매우 어려운 설명\n## 소제목",
+            Arrays.asList("a", "b"),
+            "1 2\n3",
+            "3 4\n7",
+            Arrays.asList("DFS", "BFS"));
 
+    public static ExtractableResponse<Response> createProblem() {
         return given()
                 .log().all()
-                .body(requestBody)
+                .body(CREATE_PROBLEM_REQUEST)
                 .contentType(ContentType.JSON)
                 .when()
                 .post("/api/v1/problems")

--- a/src/test/java/com/nakaligoba/backend/service/impl/ProblemServiceTest.java
+++ b/src/test/java/com/nakaligoba/backend/service/impl/ProblemServiceTest.java
@@ -1,11 +1,13 @@
 package com.nakaligoba.backend.service.impl;
 
+import com.nakaligoba.backend.acceptance.fixtures.ProblemFixture;
+import com.nakaligoba.backend.controller.payload.response.ProblemResponse;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
 @SpringBootTest
 class ProblemServiceTest {
@@ -19,6 +21,17 @@ class ProblemServiceTest {
     @Test
     @DisplayName("문제 식별자로 문제 정보를 읽을 수 있다.")
     void readByProblemId() {
+        Long problemId = problemFacade.createProblem(ProblemFixture.CREATE_PROBLEM_REQUEST);
 
+        ProblemResponse problem = problemService.readProblem(problemId);
+
+        System.out.println(problem);
+        assertThat(problem.getDefaultCodes()).isNotEmpty();
+        assertThat(problem.getDefaultCodes().get("java")).contains("class Solution {\n" +
+                "    public String solve(String a, String b) {\n" +
+                "        String answer = \"\";\n" +
+                "        return answer;\n" +
+                "    }\n" +
+                "}");
     }
 }

--- a/src/test/java/com/nakaligoba/backend/service/impl/ProblemServiceTest.java
+++ b/src/test/java/com/nakaligoba/backend/service/impl/ProblemServiceTest.java
@@ -1,0 +1,24 @@
+package com.nakaligoba.backend.service.impl;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+class ProblemServiceTest {
+
+    @Autowired
+    private ProblemService problemService;
+
+    @Autowired
+    private ProblemFacade problemFacade;
+
+    @Test
+    @DisplayName("문제 식별자로 문제 정보를 읽을 수 있다.")
+    void readByProblemId() {
+
+    }
+}


### PR DESCRIPTION
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `[feat] PR을 등록한다.` 
- [ ] 💯 테스트는 잘 통과했나요?
- [x] 🏗️ 빌드는 성공했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?
- [x] 💻 git rebase를 사용했나요?

## 작업 내용

- 문제 조회 API에서 디폴트 코드가 없어서 수정했습니다.
- 현재는 java 언어만 지원하므로 AvailableLanguage를 참조하지 않고 Language에 있는 모든(Java) 언어에 대한 기본 코드를 응답에 넣었습니다.

## 스크린샷

- 테스트 코드로 대체합니다.

## 주의사항

- 문제 생성 시 DB에 저장된 언어를 기준으로 풀이 가능한 언어를 설정하는 로직을 애플리케이션의 Language 이넘의 언어로 바꿔야할 것 같습니다.
- 현재 Member 테이블에 Role이 추가되어 회원가입 테스트나 기능이 제대로 동작하지 않을 수 있습니다!!!

Closes #66 
