### PR TITLE
[fix] 문제 조회 시 채점용 테스트케이스 응답에서 제거

### DIFF
--- a/src/main/java/com/nakaligoba/backend/service/impl/ProblemService.java
+++ b/src/main/java/com/nakaligoba/backend/service/impl/ProblemService.java
@@ -88,6 +88,7 @@ public class ProblemService {
 
     private List<ProblemResponse.TestcaseResponse> getTestcases(Problem problem) {
         return problem.getTestcases().stream()
+                .filter(Testcase::isTesting)
                 .map((t) ->
                         ProblemResponse.TestcaseResponse.builder()
                                 .number(t.getNumber())

--- a/src/test/java/com/nakaligoba/backend/service/impl/ProblemServiceTest.java
+++ b/src/test/java/com/nakaligoba/backend/service/impl/ProblemServiceTest.java
@@ -1,11 +1,17 @@
 package com.nakaligoba.backend.service.impl;
 
 import com.nakaligoba.backend.acceptance.fixtures.ProblemFixture;
+import com.nakaligoba.backend.controller.payload.request.CreateProblemRequest;
 import com.nakaligoba.backend.controller.payload.response.ProblemResponse;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.function.Function;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -33,5 +39,29 @@ class ProblemServiceTest {
                 "        return answer;\n" +
                 "    }\n" +
                 "}");
+    }
+
+    @Test
+    @DisplayName("문제 식별자로 문제 조회 시 채점용 테스트케이스는 반환되지 않는다.")
+    void readProblem_withOutAnswerCase() {
+        String testcase = "1 2\n3";
+        List<String> answerCaseInputs = List.of("3", "4");
+        String answerCase = "3 4\n7";
+        CreateProblemRequest requestBody = new CreateProblemRequest("겁나 어려운 문제",
+                "어려움",
+                "# 설명\n매우 어려운 설명\n## 소제목",
+                Arrays.asList("a", "b"),
+                testcase,
+                answerCase,
+                Arrays.asList("DFS", "BFS"));
+        Long problemId = problemFacade.createProblem(requestBody);
+
+        ProblemResponse problem = problemService.readProblem(problemId);
+
+        problem.getTestcases()
+                .stream()
+                .map(ProblemResponse.TestcaseResponse::getInputs)
+                .flatMap(Collection::stream)
+                .forEach((v) -> assertThat(v).isNotIn("3", "4"));
     }
 }


### PR DESCRIPTION
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `[feat] PR을 등록한다.` 
- [x] 💯 테스트는 잘 통과했나요?
- [x] 🏗️ 빌드는 성공했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?
- [x] 💻 git rebase를 사용했나요?

## 작업 내용

- 문제 조회 시 정답 케이스도 함께 반환 되는 버그 수정

Closes #67
