### PR TITLE
[fix] reply 목록 조회시 author id와 isLike를 반환에 추가

### DIFF
--- a/src/main/java/com/nakaligoba/backend/controller/ReplyController.java
+++ b/src/main/java/com/nakaligoba/backend/controller/ReplyController.java
@@ -24,13 +24,13 @@ import javax.validation.Valid;
 
 @RequiredArgsConstructor
 @RestController
-@RequestMapping("/api/v1/comments")
+@RequestMapping("/api/v1/comments/{commentId}/replies")
 public class ReplyController {
 
     private final ReplyService replyService;
     private final ReplyLikeService replyLikeService;
 
-    @PostMapping("/{commentId}/replies")
+    @PostMapping
     public ResponseEntity<Void> createReply(
             @PathVariable Long commentId,
             @Valid @RequestBody ReplyRequest request
@@ -43,7 +43,7 @@ public class ReplyController {
                 .build();
     }
 
-    @PutMapping("/{commentId}/replies/{replyId}")
+    @PutMapping("/{replyId}")
     public ResponseEntity<Void> updateReply(
             @PathVariable Long commentId,
             @PathVariable Long replyId,
@@ -55,7 +55,7 @@ public class ReplyController {
         return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
     }
 
-    @GetMapping("{commentId}/replies")
+    @GetMapping
     public ResponseEntity<RepliesResponse> readReplies(@PathVariable Long commentId) {
         String loggedInEmail = JwtUtils.getEmailFromSpringSession();
         RepliesResponse repliesResponse = replyService.readReplies(loggedInEmail, commentId);
@@ -63,19 +63,19 @@ public class ReplyController {
         return ResponseEntity.status(HttpStatus.OK).body(repliesResponse);
     }
 
-    @PostMapping("/{commentId}/replies/{replyId}/like")
+    @PostMapping("/{replyId}/like")
     public ResponseEntity<ReplyLikeResponse> likeReply(
             @PathVariable Long commentId,
             @PathVariable Long replyId,
             @RequestBody ReplyLikeRequest request
     ) {
         String loggedInEmail = JwtUtils.getEmailFromSpringSession();
-        boolean isLiked = replyLikeService.likeReply(loggedInEmail, commentId, replyId, request.getRequestDateTime());
+        boolean isLiked = replyLikeService.toggleLike(loggedInEmail, commentId, replyId, request.getRequestDateTime());
 
         return ResponseEntity.status(HttpStatus.OK).body(new ReplyLikeResponse(isLiked));
     }
 
-    @DeleteMapping("/{commentId}/replies/{replyId}")
+    @DeleteMapping("/{replyId}")
     public ResponseEntity<Void> deleteReply(
             @PathVariable Long commentId,
             @PathVariable Long replyId

--- a/src/main/java/com/nakaligoba/backend/controller/SolutionController.java
+++ b/src/main/java/com/nakaligoba/backend/controller/SolutionController.java
@@ -36,7 +36,7 @@ public class SolutionController {
                 .build();
     }
 
-    @PutMapping("{problemId}/solutions/{solutionId}")
+    @PutMapping("/{problemId}/solutions/{solutionId}")
     public ResponseEntity<Void> updateSolution(
             @PathVariable Long problemId,
             @PathVariable Long solutionId,

--- a/src/main/java/com/nakaligoba/backend/domain/ReplyLike.java
+++ b/src/main/java/com/nakaligoba/backend/domain/ReplyLike.java
@@ -27,8 +27,8 @@ public class ReplyLike extends BaseEntity {
     @JoinColumn(name = "member_id")
     private Member member;
 
-    public ReplyLike(Reply reply, Member member) {
-        this.reply = reply;
+    public ReplyLike(Member member, Reply reply) {
         this.member = member;
+        this.reply = reply;
     }
 }

--- a/src/main/java/com/nakaligoba/backend/repository/ReplyLikeRepository.java
+++ b/src/main/java/com/nakaligoba/backend/repository/ReplyLikeRepository.java
@@ -5,12 +5,15 @@ import com.nakaligoba.backend.domain.Reply;
 import com.nakaligoba.backend.domain.ReplyLike;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface ReplyLikeRepository extends JpaRepository<ReplyLike, Long> {
     void deleteByReplyId(Long replyId);
 
-    boolean existsByMemberAndReply(Member member, Reply reply);
+    Optional<ReplyLike> findByMemberAndReply(Member member, Reply reply);
 
-    void deleteByMemberAndReply(Member member, Reply reply);
+
+   boolean existsByMemberIdAndReplyId(Long memberId, Long replyId);
 
     Long countByReplyId(Long replyId);
 }

--- a/src/main/java/com/nakaligoba/backend/service/dto/ReplyDto.java
+++ b/src/main/java/com/nakaligoba/backend/service/dto/ReplyDto.java
@@ -15,4 +15,5 @@ public class ReplyDto {
     private AuthorDto author;
     private String content;
     private Long likeCount;
+    private boolean isLike;
 }

--- a/src/main/java/com/nakaligoba/backend/service/impl/CommentService.java
+++ b/src/main/java/com/nakaligoba/backend/service/impl/CommentService.java
@@ -120,7 +120,7 @@ public class CommentService {
         return commentPage.getContent().stream()
                 .map(comment -> Comments.builder()
                         .author(AuthorDto.builder()
-                                .id(memberId)
+                                .id(comment.getMember().getId())
                                 .avatar("")
                                 .nickname(comment.getMember().getNickname())
                                 .build())

--- a/src/main/java/com/nakaligoba/backend/service/impl/ReplyService.java
+++ b/src/main/java/com/nakaligoba/backend/service/impl/ReplyService.java
@@ -80,10 +80,12 @@ public class ReplyService {
                             .replyId(reply.getId())
                             .content(reply.getContent())
                             .author(AuthorDto.builder()
+                                    .id(member.getId())
                                     .avatar("")
                                     .nickname(reply.getMember().getNickname())
                                     .build())
                             .likeCount(replyLikeService.getReplyLikeCount(reply.getId()))
+                            .isLike(replyLikeService.getIsReplyLike(member.getId(), reply.getId()))
                             .build()
                 )
                 .collect(Collectors.toList());

--- a/src/main/java/com/nakaligoba/backend/service/impl/ReplyService.java
+++ b/src/main/java/com/nakaligoba/backend/service/impl/ReplyService.java
@@ -80,7 +80,7 @@ public class ReplyService {
                             .replyId(reply.getId())
                             .content(reply.getContent())
                             .author(AuthorDto.builder()
-                                    .id(member.getId())
+                                    .id(reply.getMember().getId())
                                     .avatar("")
                                     .nickname(reply.getMember().getNickname())
                                     .build())


### PR DESCRIPTION
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `[feat] PR을 등록한다.` 
- [x] 💯 테스트는 잘 통과했나요?
- [x] 🏗️ 빌드는 성공했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?
- [x] 💻 git rebase를 사용했나요?

## 작업 내용

- 답글 목록 조회시 isLike 상태를 확인할 수 있게 isLike를 추가하였습니다.
- API 테스트시 Author의 id도 반환되지 않은 것을 확인하여 Author id도 같이 반환하도록 수정하였습니다.

## 스크린샷

<img width="557" alt="image" src="https://github.com/NaKaLiGoBa/AlgoWithMe-BE/assets/67509973/bfc342ed-feb8-4c6b-bf58-8424a7169bbf">

<img width="841" alt="image" src="https://github.com/NaKaLiGoBa/AlgoWithMe-BE/assets/67509973/988a7adf-0ea1-4888-9926-355c66b879f2">



## 주의사항

Closes #138
