### PR TITLE
[fix] 풀이글 생성 및 수정 시 인가 검증 추가

### DIFF
--- a/src/main/java/com/nakaligoba/backend/controller/ReplyController.java
+++ b/src/main/java/com/nakaligoba/backend/controller/ReplyController.java
@@ -11,14 +11,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.PutMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
 
@@ -63,7 +56,7 @@ public class ReplyController {
         return ResponseEntity.status(HttpStatus.OK).body(repliesResponse);
     }
 
-    @PostMapping("/{replyId}/like")
+    @PutMapping("/{replyId}/like")
     public ResponseEntity<ReplyLikeResponse> likeReply(
             @PathVariable Long commentId,
             @PathVariable Long replyId,

--- a/src/test/java/com/nakaligoba/backend/service/impl/ProblemServiceTest.java
+++ b/src/test/java/com/nakaligoba/backend/service/impl/ProblemServiceTest.java
@@ -347,13 +347,13 @@ class ProblemServiceTest {
 
         Long createdProblemId = problemFacade.createProblem(ProblemFixture.CREATE_PROBLEM_REQUEST);
         Problem findProblem = problemRepository.findById(createdProblemId).orElseThrow(EntityNotFoundException::new);
-        submitService.save(code, Result.FAIL, findProblem, member1);
-        submitService.save(code, Result.FAIL, findProblem, member1);
-        submitService.save(code, Result.FAIL, findProblem, member2);
-        submitService.save(code, Result.COMPILE_ERROR, findProblem, member1);
-        submitService.save(code, Result.RESOLVED, findProblem, member1);
-        submitService.save(code, Result.FAIL, findProblem, member2);
-        submitService.save(code, Result.RESOLVED, findProblem, member2);
+        submitService.create(code, Language.JAVA, Result.FAIL, findProblem, member1, "N/A", "N/A", "N/A", "N/A");
+        submitService.create(code, Language.JAVA, Result.FAIL, findProblem, member1, "N/A", "N/A", "N/A", "N/A");
+        submitService.create(code, Language.JAVA, Result.FAIL, findProblem, member2, "N/A", "N/A", "N/A", "N/A");
+        submitService.create(code, Language.JAVA, Result.COMPILE_ERROR, findProblem, member1, "N/A", "N/A", "N/A", "N/A");
+        submitService.create(code, Language.JAVA, Result.RESOLVED, findProblem, member1, "N/A", "N/A", "N/A", "N/A");
+        submitService.create(code, Language.JAVA, Result.FAIL, findProblem, member2, "N/A", "N/A", "N/A", "N/A");
+        submitService.create(code, Language.JAVA, Result.RESOLVED, findProblem, member2, "N/A", "N/A", "N/A", "N/A");
 
         BigDecimal seven = new BigDecimal("7");
         BigDecimal two = new BigDecimal("2");


### PR DESCRIPTION
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `[feat] PR을 등록한다.` 
- [x] 💯 테스트는 잘 통과했나요?
- [x] 🏗️ 빌드는 성공했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?
- [x] 💻 git rebase를 사용했나요?

## 작업 내용

- 풀이글 수정 서비스 로직에 인가 검증하는 부분이 누락된거같아서 다시 추가하였습니다.
- 풀이글 생성 호출 시, 해당 문제의 Submit들 중 해당 멤버의 Submit들 중 성공이 없다면, 권한 예외를 던졌습니다.


## 스크린샷

- 테스트 코드를 작성하였습니다.

## 주의사항

- 쿼리 레벨에서 시도하면 더욱 최적화가 될 수 있었지만, 쿼리 부분을 적용 중 계속 실패하여 서비스 로직에 Submit들을 모두 확인하는
비효율적인 방법을 이용하였습니다..

Closes #142
